### PR TITLE
Add homeshick to list of frameworks

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,8 @@
         and mappings for Vim, Gvim and MacVim.</li>
         <li><a href="https://github.com/philips/ghar">Brandon Philip's ghar</a> is a standalone
         Python script for managing git repos symlinked into your home.</li>
+        <li><a href="https://github.com/andsens/homeshick">Anders Ingemann's homeshick</a> is a
+        standalone bash script for managing git repos symlinked into your home.</li>
         </ul>
         
         


### PR DESCRIPTION
A little self-promotion here. I thought homeshick might be a nice addition to the list, since it has no dependencies at all, besides bash and git.
