### PR TITLE
Fix grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ to help you manage them.</p>
 
 <p>Consider using <a href="http://help.github.com/submodules/">Git submodules</a> as you
 start to add 3<sup>rd</sup> party frameworks, scripts, and plugins. Submodules make
-managing dotfile dependencies with so much easier.</p>
+managing dotfile dependencies so much easier.</p>
 <h2>FAQ</h2>
 <dl class='faq'>
   <dt>Why create this site?</dt>

--- a/src/content/index.haml
+++ b/src/content/index.haml
@@ -76,7 +76,7 @@ title: GitHub does dotfiles
 
   Consider using [Git submodules](http://help.github.com/submodules/) as you
   start to add 3<sup>rd</sup> party frameworks, scripts, and plugins. Submodules make
-  managing dotfile dependencies with so much easier.
+  managing dotfile dependencies so much easier.
 
 %h2 FAQ
 


### PR DESCRIPTION
Fixed grammar in the Submodules section.

This was recently fixed by elidupuis, but the most recent commit seems to have reverted this change.
