### PR TITLE
Cowboy's dotfiles appear twice

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,8 +109,6 @@
         and mappings for Vim, Gvim and MacVim.</li>
         <li><a href="https://github.com/philips/ghar">Brandon Philip&#39;s ghar</a> is a standalone
         Python script for managing git repos symlinked into your home.</li>
-        <li><a href="https://github.com/cowboy/dotfiles">Ben Alman&#39;s dotfiles</a> support
-        different configurations per OS, linking, copying and environment setup.</li>
         <li><a href="https://github.com/freshshell/fresh">fresh</a> is a tool to source dotfiles
         from others into your own. It supports shell configuration (aliases,
         functions, etc.) as well as config files (e.g. <code>ackrc</code> and <code>gitconfig</code>).


### PR DESCRIPTION
I thought it might make more sense for them to be in the "Get started with a bootstrap" section instead of the "Go farther with a framework" section.
