### PR TITLE
Cowboy's dotfiles appear twice

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -57,8 +57,6 @@ is a "shameless ripoff of oh-my-zsh," but for bash.
 and mappings for Vim, Gvim and MacVim.
 * [Brandon Philip's ghar](https://github.com/philips/ghar) is a standalone
 Python script for managing git repos symlinked into your home.
-* [Ben Alman's dotfiles](https://github.com/cowboy/dotfiles) support
-different configurations per OS, linking, copying and environment setup.
 * [fresh](https://github.com/freshshell/fresh) is a tool to source dotfiles
 from others into your own. It supports shell configuration (aliases,
 functions, etc.) as well as config files (e.g. `ackrc` and `gitconfig`).


### PR DESCRIPTION
Thinking it might make more sense for them to be in the "Get Started with a
Bootstrap" section instead of the "Go Farther with a Framework" section.

This is the same pull request as #33, except this time against the `source`
branch. Sorry for not reading the contributing documentation more carefully!
