### PR TITLE
add link to xero's dotfiles, with info about managing them with gnu stow

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -41,6 +41,7 @@ greatly customized zsh with auto-completion and syntax highlighting,
 a bunch of useful git extras and colourful themes for OS X Terminal and Sublime Text 2.
 * [Eduardo Lundgren's dotfiles](https://github.com/eduardolundgren/dotfiles),
 the first JavaScript-based dotfiles powered by Grunt.
+* [xero's dotfiles](http://git.io/.files) are managed with gnu stow, a free, portable, lightweight symlink farm manager.
 
 ## Go farther with a framework
 


### PR DESCRIPTION
in the linux world we take dotfiles seriously. i've started to manage mine with gnu stow, and it's been great. the [readme](https://github.com/xero/dotfiles/blob/master/README.md) in my dotfiles repo is a guide dedicated to teaching people to use stow to manage theirs (and work with mine). people must like the idea, because i have a growing number of forks and stars :grinning: 

my dotfiles have _lots_ of configs and themes including: 
- awesome wm
- compton
- linux fonts
- figlet
- git
- herbstluftwm
- midnight commander
- mpd
- ncmpcpp
- pacman
- sublime text
- vim
- urxvt
- zsh
