### PR TITLE
Add Andrew Schwartzmeyer's dotfiles

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -26,6 +26,7 @@ out of the process. Here are a few of our favorites:
 * [Eduardo Lundgren's dotfiles](https://github.com/eduardolundgren/dotfiles), the first JavaScript-based dotfiles powered by Grunt.
 * [xero's dotfiles](http://git.io/.files) are managed with gnu stow, a free, portable, lightweight symlink farm manager.
 * [Adam Eivy's dotfiles](https://github.com/atomantic/dotfiles) are focused on Automation (no manual install/config) for Zsh and OSX with a friendly bot to guide your way.
+* [Andrew Schwartzmeyer's dotfiles](https://github.com/andschwa/dotfiles) use [myrepos](http://myrepos.branchable.com/) in combination with [vcsh](https://github.com/RichiH/vcsh) to let there exist a togglable Git repository for each set of dotfiles, even those coexisting in the same directory. There's even a `bootstrap` script.
 
 ## Go farther with a framework
 


### PR DESCRIPTION
I've been using this setup to manage my dotfiles for a while and found that it works to my liking very well. I can deploy any set of dotfiles to various Linux and OS X machines with no problem; figured I might as well share it.