### PR TITLE
Add fisherman https://github.com/fisherman/fisherman to fish section.

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,6 +50,8 @@ customization safe and easy.
 
 #### Fish
 
+* [fisherman](https://github.com/fisherman/fisherman) Zero-configuration, concurrent plugin manager for the fish shell – http://fisherman.sh
+
 * [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) a fish shell framework inspired by oh-my-zsh.
 
 #### Zsh


### PR DESCRIPTION
Hi. Can we add fisherman to the list?

fisherman is a concurrent plugin manager for the fish shell and [plugin ecosystem](https://github.com/fisherman).

**Crosslinks**
* https://github.com/fisherman/fisherman/issues/217