### PR TITLE
Fix fisherman link and use correct words in description.

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,8 +50,8 @@ customization safe and easy.
 
 #### Fish
 
-* [fisherman](http://fisherman.sh) is a zero-configuration, concurrent plugin manager for the [fish shell](http://fish.sh)
-* [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) a fish shell framework inspired by oh-my-zsh.
+* [fisherman](http://github.com/fisherman/fisherman) is a concurrent plugin manager for [fish shell](http://fish.sh)
+* [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) is a fish-shell framework inspired by oh-my-zsh.
 
 #### Zsh
 

--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ customization safe and easy.
 
 #### Fish
 
-* [fisherman](http://github.com/fisherman/fisherman) is a concurrent plugin manager for [fish shell](http://fish.sh)
+* [fisherman](http://github.com/fisherman/fisherman) is a concurrent plugin manager for [fish-shell](http://fish.sh)
 * [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) is a fish-shell framework inspired by oh-my-zsh.
 
 #### Zsh


### PR DESCRIPTION
The current link points to the homepage, but I'd rather have it pointing to github repository.

I also added some wording consistency and fixed my own mistake, please squash merge.