### PR TITLE
Remove gmarmstrong's dotfiles, add rycee's home-manager

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,6 @@ out of the process. Here are a few of our favorites:
 * [Dries Vints' dotfiles](https://github.com/driesvints/dotfiles) leverages [Brew](https://github.com/driesvints/dotfiles/blob/master/Brewfile) and [mackup](https://github.com/lra/mackup) to setup an entire macOS environment.
 * [Eduardo Lundgren's dotfiles](https://github.com/eduardolundgren/dotfiles), the first JavaScript-based dotfiles powered by Grunt.
 * [F-dotfiles](https://github.com/Kraymer/F-dotfiles) is an opinionated dotfiles organization scheme based on GNU Stow. Highest priorities are ease of maintenance and deployment on both Linux and macOS.
-* [Guthrie McAfee Armstrong's dotfiles](https://github.com/gmarmstrong/dotfiles) declare a [NixOS](https://nixos.org) system configuration and user environment with [Home Manager](https://github.com/rycee/home-manager) for Nix. The Nix configuration is purely functional and reproducible.
 * [Jeff Coffler's dotfiles](https://github.com/jeffaco/dotfiles) has a bootstrap script that symlinks and doesn't require "." (hidden file) in the repo. The repo itself can live anywhere.
 * [jh3y's kody](https://github.com/jh3y/kody) is a dotfiles runner/manager written with node inspired by Zach Holman's popular dotfiles.
 * [kutsan's dotfiles](https://github.com/kutsan/dotfiles) includes ongoing configuration files for various interfaces and text-based command-line applications such as vim, zsh, tmux, ranger, mutt, newsboat and more.

--- a/index.md
+++ b/index.md
@@ -121,6 +121,7 @@ customization safe and easy.
 * [Ghar](https://github.com/philips/ghar) by Brandon Philip. Ghar is a standalone Python script for managing Git repos symlinked into your home.
 * [GNU Stow](https://www.gnu.org/software/stow/) is a symlink farm manager, useful for automatically (and safely) linking your dotfiles folder into your home directory.
 * [Homely](https://homely.readthedocs.io/) helps you script your dotfile installation using Python. If you're getting frustrated by the limitations of pure shell scripts, then this is the tool for you. Homely also has a clever Automatic Cleanup feature and good tutorials.
+* [Home Manager](https://github.com/rycee/home-manager) by Robert Helgesson is a system built for managing [NixOS](https://nixos.org) user environments using the [Nix](https://nixos.org/nix/) package manager and the [Nixpkgs](https://nixos.org/nixpkgs/) libraries.
 * [Homemaker](https://github.com/FooSoft/homemaker) by Alex Yatskov. Homemaker is a standalone tool written in Golang to manage both common and machine-specific dotfile settings. Homemaker can be configured in TOML, YAML or JSON.
 * [Homeshick](https://github.com/andsens/homeshick) by Anders Ingemann is like Homesick but written in bash. Great to combine with [myrepos](https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/).
 * [Homesick](https://github.com/technicalpickles/homesick), by Josh Nichols. Homesick makes it easy to symlink and clone dotfiles repos.


### PR DESCRIPTION
See commits. I misread the purpose of the section, and added my dotfiles despite them not being a suitable bootstrap for forking. Still, the framework used is neat, so adding [rycee/home-manager](https://github.com/rycee/home-manager) to the general purpose utilities.