### PR TITLE
Delete link to article that has gone 404

### DIFF
--- a/index.md
+++ b/index.md
@@ -153,7 +153,6 @@ customization safe and easy.
 
 ### Tutorials
 
-* Abdullah Khan wrote [How to manage dotfiles securely](https://theak.me/blog/how-to-manage-dotfiles.html) which shows how you can encrypt your dotfiles using your gpg keys.
 * Lars Kappert wrote a [tutorial](https://medium.com/@webprolific/getting-started-with-dotfiles-43c3602fd789) about getting started using a dotfiles repository.
 * Anish Athalye wrote a [guide on dotfiles management](http://www.anishathalye.com/2014/08/03/managing-your-dotfiles/) highlighting organizational approaches, installation tools, and general tips and tricks.
 * Wes Bos has a series of [free videos](https://commandlinepoweruser.com/) introducing ZSH, oh-my-zsh, and z.


### PR DESCRIPTION
[How to manage dotfiles securely](https://theak.me/blog/how-to-manage-dotfiles.html) is 404, and the base site has a bad SSL cert.