### PR TITLE
Add kornicameister's dotfiles

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,6 +62,7 @@ out of the process. Here are a few of our favorites:
 * [xero's dotfiles](https://github.com/xero/dotfiles) are managed with [GNU Stow](https://www.gnu.org/software/stow/), a free, portable, lightweight symlink farm manager.
 * [Yan Pritzker's dotfiles](https://github.com/skwp/dotfiles) bundles an opinionated set of Vim plugins and ZSH setup all tuned for using [Solarized](https://github.com/altercation/solarized) on macOS.
 * [Zach Holman's dotfiles](https://github.com/holman/dotfiles) features topical organization, auto sourcing ZSH files, easy ZSH completion extensions, and a local bin folder for executables. The included `Rakefile` will symlink anything ending in `.symlink` to your `~` folder.
+* [kornicameister's dotfiles](https://github.com/kornicameister/dotfiles) started as a collection of manually creafted bash scripts slowing moving toward proper dotfiles utilizing ZSH (with Prezto), Pyenv, Nodenv, Terminator, Git and VIM/Neovim configuration. Everything controlled via [dotbot](https://github.com/anishathalye/dotbot) and automated down to generating GPG key to sign commit, upgrading local environment via own binary and dependencies management via [dependabot](https://dependabot.com/).
 
 ## Go further with a framework
 

--- a/index.md
+++ b/index.md
@@ -44,6 +44,7 @@ out of the process. Here are a few of our favorites:
 * [Jeff Coffler's dotfiles](https://github.com/jeffaco/dotfiles) has a bootstrap script that symlinks and doesn't require "." (hidden file) in the repo. The repo itself can live anywhere.
 * [jh3y's kody](https://github.com/jh3y/kody) is a dotfiles runner/manager written with node inspired by Zach Holman's popular dotfiles.
 * [Jonas Devlieghere's dotfiles](https://github.com/JDevlieghere/dotfiles) for both macOS and Linux has a little bit of everything for compiler development in the terminal.
+* [kornicameister's dotfiles](https://github.com/kornicameister/dotfiles) started as a collection of manually creafted bash scripts slowing moving toward proper dotfiles utilizing ZSH (with Prezto), Pyenv, Nodenv, Terminator, Git and VIM/Neovim configuration. Everything controlled via [dotbot](https://github.com/anishathalye/dotbot) and automated down to generating GPG key to sign commit, upgrading local environment via own binary and dependencies management via [dependabot](https://dependabot.com/).
 * [kutsan's dotfiles](https://github.com/kutsan/dotfiles) includes ongoing configuration files for various interfaces and text-based command-line applications such as vim, ZSH, tmux, ranger, mutt, newsboat and more.
 * [Mathias Bynens' dotfiles](https://github.com/mathiasbynens/dotfiles) includes a bootstrap script that rsyncs your repo to your home folder. Mathias' [macOS defaults script](https://github.com/mathiasbynens/dotfiles/blob/master/.macos) is legendary.
 * [Matt Smith's dotfiles](https://github.com/mattorb/dotfiles) includes a one-liner install, fish, vscode, mac desktop app installs via brew cask, os x customizations inspired by Mathias, etc.  No dotfiles framework, just shell scripts to set everything up.
@@ -62,7 +63,6 @@ out of the process. Here are a few of our favorites:
 * [xero's dotfiles](https://github.com/xero/dotfiles) are managed with [GNU Stow](https://www.gnu.org/software/stow/), a free, portable, lightweight symlink farm manager.
 * [Yan Pritzker's dotfiles](https://github.com/skwp/dotfiles) bundles an opinionated set of Vim plugins and ZSH setup all tuned for using [Solarized](https://github.com/altercation/solarized) on macOS.
 * [Zach Holman's dotfiles](https://github.com/holman/dotfiles) features topical organization, auto sourcing ZSH files, easy ZSH completion extensions, and a local bin folder for executables. The included `Rakefile` will symlink anything ending in `.symlink` to your `~` folder.
-* [kornicameister's dotfiles](https://github.com/kornicameister/dotfiles) started as a collection of manually creafted bash scripts slowing moving toward proper dotfiles utilizing ZSH (with Prezto), Pyenv, Nodenv, Terminator, Git and VIM/Neovim configuration. Everything controlled via [dotbot](https://github.com/anishathalye/dotbot) and automated down to generating GPG key to sign commit, upgrading local environment via own binary and dependencies management via [dependabot](https://dependabot.com/).
 
 ## Go further with a framework
 


### PR DESCRIPTION
I wanted to propose adding my dotfiles. I never encountered dotfiles that would feature:

- CI system increasing reproducibility of a system
- Full automation which CI proves and will continue to prove by extending tests coverage
- Dependency management  done via [dependabot](https://dependabot.com/) covering upgrading Python system wide dependencies along with Neovim virtual environments dependencies and used submodules for tools like `pyenv` or `fzf`

hance a decision to try and share with everyone interested that those things are possible :)