### PR TITLE
Remove broken link to abdullah  blog

### DIFF
--- a/index.md
+++ b/index.md
@@ -156,7 +156,6 @@ customization safe and easy.
 
 ### Tutorials
 
-* Abdullah wrote a [How to manage dotfiles securely](https://abdullah.today/blog/how-to-manage-dotfiles.html), a step by step guide to encrypt your dotfiles using your gpg keys.
 * Lars Kappert wrote a [tutorial](https://medium.com/@webprolific/getting-started-with-dotfiles-43c3602fd789) about getting started using a dotfiles repository.
 * Anish Athalye wrote a [guide on dotfiles management](http://www.anishathalye.com/2014/08/03/managing-your-dotfiles/) highlighting organizational approaches, installation tools, and general tips and tricks.
 * Wes Bos has a series of [free videos](https://commandlinepoweruser.com/) introducing ZSH, oh-my-zsh, and z.


### PR DESCRIPTION
Remove **How to manage dotfiles securely**  - Seems like entire page is out of picture too.

---
#224 was broken because of this link not being accessible anymore. 