### PR TITLE
Support non repo websites

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -9,12 +9,12 @@
   notes: is a minimalist dotfile management framework, written 100% in bash.
   stars: 56
   url: https://github.com/bashdot/bashdot
-- forks: 92
+- forks: 95
   name: chezmoi
   notes: makes it easy to manage your dotfiles across multiple machines, securely.
-  stars: 2109
+  stars: 2154
   url: https://github.com/twpayne/chezmoi
-- forks: 3
+- forks: 4
   name: Bonclay
   notes: is a simple dotfiles manager. Well, technically, it is a backup/restore/sync
     tool magiggy.
@@ -25,7 +25,7 @@
   notes: is a dotfile manager that has no configuration, one-command importing, one-command
     syncing, multiple repository support, automatic cleanup, and can be used with
     git or any other RCS.
-  stars: 35
+  stars: 36
   url: https://github.com/CGamesPlay/dfm
 - forks: 3
   name: Config Curator
@@ -39,24 +39,24 @@
   notes: is a utility to manage your dotfiles, lightweight and simple.
   stars: 101
   url: https://github.com/justone/dfm
-- forks: 146
+- forks: 149
   name: Dotbot
   notes: is a lightweight standalone tool to bootstrap dotfiles, making it easy to
     have a "one click" installation/upgrade process for your dotfiles.
-  stars: 2745
+  stars: 2805
   url: https://github.com/anishathalye/dotbot
 - forks: 46
   name: dotdrop
   notes: makes the management of dotfiles between different hosts easy. It allows
     to store your dotfiles on git and automagically deploy different versions on different
     setups.
-  stars: 559
+  stars: 567
   url: https://github.com/deadc0de6/dotdrop
-- forks: 26
+- forks: 27
   name: dotfiler
   notes: is inspired by homesick and [Zach Holman's dotfiles](https://github.com/holman/dotfiles),
     made using principle of KISS.
-  stars: 187
+  stars: 188
   url: https://github.com/svetlyak40wt/dotfiler
 - forks: 9
   name: dotfiles.sh
@@ -86,13 +86,13 @@
   notes: by Jam Risser. A simple cli to manage and sync dotfiles with git and stow.
     It backups dotfiles with git and keeps track of simultaneous dotfile configurations
     for multiple environments. It also supports shell autocompletion.
-  stars: 54
+  stars: 55
   url: https://github.com/codejamninja/dotstow
-- forks: 52
+- forks: 53
   name: Dotsync
   notes: utility for syncing dotfiles between multiple machines from a Git repo or
     push using rsync.
-  stars: 217
+  stars: 219
   url: https://github.com/dotphiles/dotsync
 - forks: 13
   name: dotty
@@ -104,7 +104,7 @@
 - forks: 23
   name: Ellipsis
   notes: is a package manager for dotfiles.
-  stars: 301
+  stars: 305
   url: https://github.com/ellipsis/ellipsis
 - forks: 8
   name: exogenesis
@@ -117,7 +117,7 @@
   notes: is a tool to source dotfiles from others into your own. It supports shell
     configuration (aliases, functions, etc.) as well as config files (e.g. `ackrc`
     and `gitconfig`). Think of it as _Bundler for your dotfiles_.
-  stars: 945
+  stars: 948
   url: https://github.com/freshshell/fresh
 - forks: 31
   name: Ghar
@@ -135,32 +135,32 @@
   notes: helps you script your dotfile installation using Python. If you're getting
     frustrated by the limitations of pure shell scripts, then this is the tool for
     you. Homely also has a clever Automatic Cleanup feature and good tutorials.
-  stars: 40
+  stars: 39
   url: https://github.com/phodge/homely
-- forks: 284
+- forks: 294
   name: Home Manager
   notes: by Robert Helgesson is a system built for managing [NixOS](https://nixos.org)
     user environments using the [Nix](https://nixos.org/nix/) package manager and
     the [Nixpkgs](https://nixos.org/nixpkgs/) libraries.
-  stars: 915
+  stars: 970
   url: https://github.com/rycee/home-manager
 - forks: 14
   name: Homemaker
   notes: by Alex Yatskov. Homemaker is a standalone tool written in Golang to manage
     both common and machine-specific dotfile settings. Homemaker can be configured
     in TOML, YAML or JSON.
-  stars: 189
+  stars: 191
   url: https://github.com/FooSoft/homemaker
 - forks: 121
   name: Homeshick
   notes: by Anders Ingemann is like Homesick but written in bash. Great to combine
     with [myrepos](https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/).
-  stars: 1541
+  stars: 1553
   url: https://github.com/andsens/homeshick
 - forks: 122
   name: Homesick
   notes: by Josh Nichols. Homesick makes it easy to symlink and clone dotfiles repos.
-  stars: 2198
+  stars: 2207
   url: https://github.com/technicalpickles/homesick
 - name: myrepos
   notes: is a tool to manage all your version control repositories at once.
@@ -172,20 +172,20 @@
     Dotfiles are treated as packages that coexist together seamlessly and can be fully
     controlled and synced across different systems. There is a wide range of packages
     already available in the [Official Pearl Hub](https://github.com/pearl-hub).
-  stars: 130
+  stars: 134
   url: https://github.com/pearl-core/pearl
 - forks: 103
   name: rcm
   notes: is a set of well-documented shell scripts that help manage your dotfiles.
     It is easily installable on macOS with the homebrew package manager, but works
     on all Unix operating systems.
-  stars: 2261
+  stars: 2279
   url: https://github.com/thoughtbot/rcm
-- forks: 50
+- forks: 49
   name: shallow-backup
   notes: lets you easily create lightweight backups of installed packages, applications,
     fonts and dotfiles, and automatically push them to a remote Git repository.
-  stars: 502
+  stars: 513
   url: https://github.com/alichtman/shallow-backup
 - forks: 9
   name: stowsh
@@ -197,7 +197,7 @@
     key differences that are more suitable to the deploy of dotfiles.
   stars: 2
   url: https://gitlab.com/semente/summon
-- forks: 106
+- forks: 110
   name: vcsh
   notes: by Richard "RichiH" Hartmann. `vcsh` manages all your dotfiles in Git without
     the need for symlinks. Any number of Git repositories will co-exist in parallel
@@ -205,14 +205,14 @@
     branches for different systems are supported by default. An extensive hook system
     lets you customize your repositories. `vcsh` includes batch push, pull, and status
     commands which operate on all your repositories at once.
-  stars: 1585
+  stars: 1594
   url: https://github.com/RichiH/vcsh
-- forks: 84
+- forks: 86
   name: yadm
   notes: is a dotfile management tool which supports system-specific alternate files/templating,
     enryption of private data, custom bootstrap actions, and integration with other
     git-aware tools like vim-fugitive, tig, git-crypt, etc.
-  stars: 1436
+  stars: 1470
   url: https://github.com/TheLocehiliosan/yadm
   website: https://yadm.io/
 - forks: 9
@@ -220,7 +220,7 @@
   notes: is a declarative domain specific language that allows you to specify the
     deployment of your dotfiles. It also includes a compiler and interpreter for the
     language.
-  stars: 96
+  stars: 97
   url: https://github.com/NorfairKing/super-user-spark
 - forks: 0
   name: yadoma

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -209,12 +209,12 @@
   url: https://github.com/RichiH/vcsh
 - forks: 84
   name: yadm
-  notes: by Tim Byrne. `yadm` is a dotfile management tool with 3 main features. Manages
-    files across systems using a single Git repository. Provides a way to use alternate
-    files on a specific OS or host. Supplies a method of encrypting confidential data
-    so it can safely be stored in your repository.
+  notes: is a dotfile management tool which supports system-specific alternate files/templating,
+    enryption of private data, custom bootstrap actions, and integration with other
+    git-aware tools like vim-fugitive, tig, git-crypt, etc.
   stars: 1436
   url: https://github.com/TheLocehiliosan/yadm
+  website: https://yadm.io/
 - forks: 9
   name: Super User Spark
   notes: is a declarative domain specific language that allows you to specify the

--- a/utilities.md
+++ b/utilities.md
@@ -18,7 +18,7 @@ dotfiles.
 {% endfor %}
 {% for repo in utilities %}
 {% if repo.stars > 100 %}
-<li><a href="{{ repo.url }}">{{ repo.name }}</a> ({{ repo.stars }} stars) {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}</li>
+<li><a href="{{ repo.website | default: repo.url }}">{{ repo.name }}</a> ({{ repo.stars }} stars) {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}</li>
 {% endif %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
This PR contains three changes.

1. Allows for non-GitHub websites for utilities. If `website` is provided, that will be the link, otherwise the GitHub URL is used. The GitHub URL is still used for obtaining star counts.

2. Updates the link to use the official website for the tool "yadm".

3. Updates the utilities star counts.