### PR TITLE
Update kody's star count so it appears on site

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -2,7 +2,7 @@
   name: kody
   notes: is a dotfiles runner/manager written with node inspired by Zach Holman's
     popular dotfiles.
-  stars: 97
+  stars: 101
   url: https://github.com/jh3y/kody
 - forks: 9
   name: bashdot


### PR DESCRIPTION
Noticed that kody no longer was showing on dotfiles.github.io. Did a little digging and assuming it's due to being under 100 stars. It's now broken the 100-star mark so hoping we can show it again 🤞