### PR TITLE
Order utilities by star count, utilities with stars first

### DIFF
--- a/utilities.md
+++ b/utilities.md
@@ -10,7 +10,7 @@ dotfiles.
 
 <ul>
 {% assign utilities = site.data.utilities | sort: 'stars' | reverse %}
-{% comment %}except repos first, sorted alphabetically, then others {% endcomment %}
+{% comment %}except repos first, sorted by stars{% endcomment %}
 {% for repo in utilities %}
 {% if repo.exempt %}
     <li><a href="{{ repo.url }}">{{ repo.name }}</a> {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}</li>

--- a/utilities.md
+++ b/utilities.md
@@ -10,15 +10,15 @@ dotfiles.
 
 <ul>
 {% assign utilities = site.data.utilities | sort: 'stars' | reverse %}
-{% comment %}except repos first, sorted by stars{% endcomment %}
-{% for repo in utilities %}
-{% if repo.exempt %}
-    <li><a href="{{ repo.url }}">{{ repo.name }}</a> {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}</li>
-{% endif %}
-{% endfor %}
+{% comment %}sorted by stars, exempt repos last{% endcomment %}
 {% for repo in utilities %}
 {% if repo.stars > 100 %}
 <li><a href="{{ repo.website | default: repo.url }}">{{ repo.name }}</a> ({{ repo.stars }} stars) {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}</li>
+{% endif %}
+{% endfor %}
+{% for repo in utilities %}
+{% if repo.exempt %}
+    <li><a href="{{ repo.url }}">{{ repo.name }}</a> {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}</li>
 {% endif %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
This PR selects a couple of commits from #283 based on @anishathalye's [suggestion](https://github.com/dotfiles/dotfiles.github.com/pull/283#issuecomment-751372459). It:

* Fixes the comment describing the order of utilities to match the code.
* Orders dotfile utilities with star counts on GitHub ahead of dotfile utilities with no or unknown star counts.

CI will fail, @anishathalye has fixed this in #284, and I'm happy to rebase this PR once #284 is merged.