### PR TITLE
[Close #290] 🐛Fix link 404 using web.archive.org

### DIFF
--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -357,3 +357,8 @@
     and from the variables.
   stars: 894
   url: https://github.com/owl4ce/dotfiles
+- forks: 0
+  name: Thuan Pham
+  notes: Config file (nvim,zsh,tmux,kitty,...). Target: be as lazy as possible.
+  stars: 2
+  url: https://github.com/thuanpham2311/dotfiles

--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -359,6 +359,6 @@
   url: https://github.com/owl4ce/dotfiles
 - forks: 0
   name: Thuan Pham
-  notes: Config file (nvim,zsh,tmux,kitty,...). Target: be as lazy as possible.
+  notes: Config file (nvim,zsh,tmux,kitty,...). [Target] be as lazy as possible.
   stars: 2
   url: https://github.com/thuanpham2311/dotfiles

--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -357,8 +357,3 @@
     and from the variables.
   stars: 894
   url: https://github.com/owl4ce/dotfiles
-- forks: 0
-  name: Thuan Pham
-  notes: Config file (nvim,zsh,tmux,kitty,...). [Target] be as lazy as possible.
-  stars: 2
-  url: https://github.com/thuanpham2311/dotfile

--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -357,3 +357,8 @@
     and from the variables.
   stars: 894
   url: https://github.com/owl4ce/dotfiles
+- forks: 0
+  name: Thuan Pham
+  notes: Config file (nvim,zsh,tmux,kitty,...). [Target] be as lazy as possible.
+  stars: 2
+  url: https://github.com/thuanpham2311/dotfile

--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -357,8 +357,3 @@
     and from the variables.
   stars: 894
   url: https://github.com/owl4ce/dotfiles
-- forks: 0
-  name: Thuan Pham
-  notes: Config file (nvim,zsh,tmux,kitty,...). [Target] be as lazy as possible.
-  stars: 2
-  url: https://github.com/thuanpham2311/dotfiles

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -154,7 +154,7 @@
 - forks: 130
   name: Homeshick
   notes: by Anders Ingemann is like Homesick but written in bash. Great to combine
-    with [myrepos](https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/).
+    with [myrepos](https://web.archive.org/web/20200904205236/https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/).
   stars: 1717
   url: https://github.com/andsens/homeshick
 - forks: 126


### PR DESCRIPTION
Link 404 (waiting-for-dev github user changed name or deleted)
https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/

Fixed link using web.archive.org:
https://web.archive.org/web/20200904205236/https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/