### PR TITLE
Remove dead link

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -154,7 +154,7 @@
 - forks: 130
   name: Homeshick
   notes: by Anders Ingemann is like Homesick but written in bash. Great to combine
-    with [myrepos](https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/).
+    with myrepos.
   stars: 1717
   url: https://github.com/andsens/homeshick
 - forks: 126


### PR DESCRIPTION
This fixes the CI failure seen in #292. The link https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/ no longer exists (it returns a 404).