### PR TITLE
Add dotter to the list of utilities

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -231,3 +231,8 @@
     multiple hosts, supports variable symlink targets and is infinitely hackable.
   stars: 4
   url: https://github.com/esc/yadoma
+- forks: 6
+  name: dotter
+  notes: A dotfile manager and templater written in Rust, with Windows/Linux/Mac support.
+  stars: 165
+  url: https://github.com/SuperCuber/dotter


### PR DESCRIPTION
[Dotter](https://github.com/SuperCuber/dotter) is still WIP, ye,t it already supports Windows. This commit proposes adding it to help fellow Windows' users to manage their dotfiles.