### PR TITLE
Handle deleted repos when updating star counts

### DIFF
--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -141,15 +141,6 @@
   stars: 452
   subcategory: ZSH
   url: https://github.com/unixorn/zsh-quickstart-kit
-- category: Shell
-  forks: 128
-  name: zplugin
-  notes: is an elastic and fast ZSH plugin manager that will allow you to install
-    everything from GitHub and other sites. Zplugin has Turbo mode which yields 50-80%
-    faster ZSH startup!
-  stars: 2700
-  subcategory: ZSH
-  url: https://github.com/zdharma/zplugin
 - category: Editors
   forks: 145
   name: Cask

--- a/script/update-star-count.py
+++ b/script/update-star-count.py
@@ -4,6 +4,7 @@
 
 import yaml
 from github import Github
+from github.GithubException import UnknownObjectException
 import argparse
 
 def main():
@@ -20,7 +21,10 @@ def main():
     for i, elem in enumerate(data):
         if elem['url'].startswith('https://github.com/'):
             repo_name = elem['url'][len('https://github.com/'):]
-            repo = g.get_repo(repo_name)
+            try:
+                repo = g.get_repo(repo_name)
+            except UnknownObjectException:
+                continue
             stars = repo.watchers
             forks = repo.forks
             elem['stars'] = stars


### PR DESCRIPTION
The [last update starcount GitHub Action](https://github.com/dotfiles/dotfiles.github.com/actions/runs/1424913012) failed with the message:

```
...
17/31 unixorn/zsh-quickstart-kit -- 457 stars, 67 forks
Traceback (most recent call last):
  File "script/update-star-count.py", line 36, in <module>
    main()
  File "script/update-star-count.py", line 23, in main
    repo = g.get_repo(repo_name)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/github/MainClass.py", line 330, in get_repo
    headers, data = self.__requester.requestJsonAndCheck("GET", url)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/repos#get-a-repository"}
Error: Process completed with exit code 1.
```

This is because it was trying to update the star counts for https://github.com/zdharma/zplugin, which no longer exists. Indeed, the GitHub user https://github.com/zdharma no longer exists.

This PR makes two changes:
1. Update the `update-star-count.py` script to handle skip deleted repos.
2. Remove the https://github.com/zdharma/zplugin repo.

I've tested this locally, and, after apply these changes, the `update-star-count.py` script completes successfully.