### PR TITLE
Only show dotfile repos with more than 50 stars in inspiration

### DIFF
--- a/inspiration.md
+++ b/inspiration.md
@@ -14,6 +14,8 @@ request](https://github.com/dotfiles/dotfiles.github.com/pulls)!
 <ul>
 {% assign inspiration = site.data.inspiration | sort: 'stars' | reverse %}
 {% for repo in inspiration %}
+{% if repo.stars > 50 %}
 <li><a href="{{ repo.url }}">{{ repo.name }}'s dotfiles</a>{% if repo.notes %} {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}{% endif %}</li>
+{% endif %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
Dotfile utilities are only shown if they have at least 100 stars. Apply
a similar criteria to inspiration.

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.
