### PR TITLE
Fix dead link to chezmoi compare 

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -13,7 +13,7 @@
   name: chezmoi
   notes: makes it easy to manage your dotfiles across multiple machines, securely.
     chezmoi is easy to install, quick to start with, and is very powerful. Read how
-    [chezmoi compares to other dotfile managers](https://github.com/twpayne/chezmoi/blob/master/docs/COMPARISON.md).
+    [chezmoi compares to other dotfile managers](https://www.chezmoi.io/comparison-table/).
   stars: 5824
   url: https://github.com/twpayne/chezmoi
 - forks: 3


### PR DESCRIPTION
The existing chezmoi compare link seems to be dead as of https://github.com/twpayne/chezmoi/pull/1826/. This PR updates that link.

<table>
<tr>
	<td>Dead link
	<td>https://github.com/twpayne/chezmoi/blob/master/docs/COMPARISON.md
<tr>
	<td>New link
	<td>https://www.chezmoi.io/comparison-table/
</table>

![image](https://user-images.githubusercontent.com/20099646/150235156-2c8fdbe8-6234-43ae-9ddf-eeeca604f30e.png)


---

<details>
<summary>PR Template</summary>

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.

# Things to look out for

Make sure that if your `notes` field in any additions/updates you make to the YAML files in the `_data` directory contains any `:` characters that the entire field is quoted as shown below:

Valid:

```yaml
foo: "bar: baz"
```

Invalid:

```yaml
foo: bar: baz
```


</details>
