### PR TITLE
Added rhysd/dotfiles CLI app

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -251,3 +251,8 @@
   stars: 203
   url: https://github.com/comtrya/comtrya
   website: https://www.comtrya.dev/
+- forks: 5
+  name: dotfiles
+  notes: Dotfiles symbolic links management CLI written in Go, with Windows/Linux/Mac support.
+  stars: 156
+  url: https://github.com/rhysd/dotfiles


### PR DESCRIPTION
This app is another dotfiles management utility app.  It is written in Go, and it works cross-platform with no dependency except for its binary and optionally git.  One unique feature is that it has symlink mapping for each platform, ie for Mac, Windows, Linux, and Linux-like.

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.

# Things to look out for

Make sure that if your `notes` field in any additions/updates you make to the YAML files in the `_data` directory contains any `:` characters that the entire field is quoted as shown below:

Valid:

```yaml
foo: "bar: baz"
```

Invalid:

```yaml
foo: bar: baz
```
