### PR TITLE
Update stale links

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -19,7 +19,7 @@ Great! We're always looking for new projects to follow. Please submit a PR or an
 ## Oh no! I've committed passwords/API keys/other sensitive data!
 
 We've got you covered! Take a look at the [sensitive data removal
-guide](https://help.github.com/articles/remove-sensitive-data/).
+guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository).
 
 ## Your FAQ is weak. It *so* did not answer my question.
 

--- a/tips.md
+++ b/tips.md
@@ -13,7 +13,7 @@ You might also consider using [gitignore.io](https://gitignore.io) to generate `
 
 ## Embrace submodules / subtrees
 
-Consider using [Git submodules](https://help.github.com/submodules/) as you
+Consider using [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) as you
 start to add 3<sup>rd</sup> party frameworks, scripts, and plugins. Submodules make
 managing dotfile dependencies so much easier.
 


### PR DESCRIPTION
Github moved some documentation, so update links accordingly

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.
