### PR TITLE
Add webpro/dotfiles to inspiration

### DIFF
--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -434,3 +434,8 @@
   notes: Well-maintained dotfile setup for macOS workstations based on Ansible.
   stars: 16
   url: https://github.com/frdmn/dotfiles
+- forks: 197
+  name: webpro
+  notes: Dotfiles for macOS. Makefile and Homebrew-based installation, up-to-date and well-organized, weekly tested.
+  stars: 872
+  url: https://github.com/webpro/dotfiles


### PR DESCRIPTION
Dotfiles for macOS. Makefile and Homebrew-based installation, up-to-date and well-organized, weekly tested.

I think this dotfiles setup is using the right tools for the jobs that it should cover, which hopefully inspires others.

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.