### PR TITLE
Add symly to the list of utilities

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -257,6 +257,14 @@
   url: https://github.com/rhysd/dotfiles
 - forks: 0
   name: symly
-  notes: Utility for centralizing sparse file trees with symbolic links
+  notes: is a utility for centralizing sparse file trees with symbolic links.
+    It replicates and maintains a file tree structure of one or more repository
+    layers into a directory) by creating symbolic links. For the dotfile
+    management use case, the directory would be the user's home. Repositories
+    are combined in an overriding fashion similar to what is done by OverlayFS.
+    There is no database; the filesystem is the state! Finally, symly only
+    focuses on managing the symbolic links but does not focus on backup and
+    synchronization. You can therefore rely on your preferred tool for the job
+    (rsync, git, Dropbox, Tresorit, ...)
   stars: 7
   url: https://github.com/loicrouchon/symly

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -255,3 +255,8 @@
     support.
   stars: 181
   url: https://github.com/rhysd/dotfiles
+- forks: 0
+  name: symly
+  notes: Utility for centralizing sparse file trees with symbolic links
+  stars: 7
+  url: https://github.com/loicrouchon/symly


### PR DESCRIPTION
I would like to propose adding Symly to the list of utilities.

Symly is a tool helping to centralize sparse file trees. It replicates and maintains a file tree structure of one or more repository layers into a directory by creating symbolic links.

* **Layers**: Symly supports the definition of multiple repositories. Those repositories will be combined in an overriding fashion similar to what is done by OverlayFS.
* **No database**: the filesystem is the state
* **Backup, Sharing, and Synchronization tool of your choice**: Symly replicates the file tree of the repositories inside another file tree using symbolic links. But it doesn’t provide a way to share, synchronize, or back up the content of the repositories. You can then decide to use one or more tools of your choice for this task: git, rsync, Dropbox, Tresorit, …​

Disclaimer: I'm the author of Symly