### PR TITLE
Add Mackup, a settings/config manager

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -267,3 +267,8 @@
     the job (rsync, git, Dropbox, Tresorit, ...)
   stars: 7
   url: https://github.com/loicrouchon/symly
+- forks: 920
+  name: Mackup
+  notes: is an application settings and configuration manager. It automatically finds the location of settings files for a set of known applications and syncs them with Dropbox, Git, or any other supported method.
+  stars: 13708
+  url: https://github.com/lra/mackup


### PR DESCRIPTION
# Description

Mackup is an extremely popular tool for managing settings and configuration for applications. This adds an entry to the "General-purpose dotfile utilities" section.

Closes #172

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.

