### PR TITLE
docs: Fix install/boot project instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ See the [CONTRIBUTING][contributing] guide for creating great pull requests.
 
 Install project dependencies:
 
-    script/bootstrap
+    ./script/bootstrap
 
 Boot local web server to preview changes:
 
-    script/server
+    ./script/server
 
 You can now browse to [http://localhost:8484][local] to preview changes.
 


### PR DESCRIPTION
# Description

The assumption that by default, `.` is an entry in the `PATH` is not (no longer) true. Because modern Linux systems (and likely macOS) do not automatically add `.` to the path, these instructions will not work if followed verbatim. Make edits to use a path that starts with `./`.

 
# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.

