### PR TITLE
Fix star updater and build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,6 @@ jobs:
             {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}
           ignore_url: |
             https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository
+          ignore_url_re: |
+            ^https://twitter.com/
+            ^https://reddit.com/

--- a/.github/workflows/update-star-counts.yml
+++ b/.github/workflows/update-star-counts.yml
@@ -7,7 +7,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/update-star-counts.yml
+++ b/.github/workflows/update-star-counts.yml
@@ -15,11 +15,23 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install PyGithub PyYAML
-    - name: Update star counts
+    - name: Update star counts (bootstrap.yml)
       run: |
         script/update-star-count.py --token $GITHUB_TOKEN _data/bootstrap.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update star counts (frameworks.yml)
+      run: |
         script/update-star-count.py --token $GITHUB_TOKEN _data/frameworks.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update star counts (inspiration.yml)
+      run: |
         script/update-star-count.py --token $GITHUB_TOKEN _data/inspiration.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update star counts (utilities.yml)
+      run: |
         script/update-star-count.py --token $GITHUB_TOKEN _data/utilities.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/script/update-star-count.py
+++ b/script/update-star-count.py
@@ -19,19 +19,23 @@ def main():
         data = yaml.safe_load(fin)
 
     for i, elem in enumerate(data):
-        if elem['url'].startswith('https://github.com/'):
-            repo_name = elem['url'][len('https://github.com/'):]
-            try:
-                repo = g.get_repo(repo_name)
-            except UnknownObjectException:
-                continue
-            stars = repo.watchers
-            forks = repo.forks
-            elem['stars'] = stars
-            elem['forks'] = forks
-            print('{}/{} {} -- {} stars, {} forks'.format(i+1, len(data), repo_name, stars, forks))
-        else:
-            print('{}/{} skipping {}'.format(i+1, len(data), elem['url']))
+        try:
+            if elem['url'].startswith('https://github.com/'):
+                repo_name = elem['url'][len('https://github.com/'):]
+                try:
+                    repo = g.get_repo(repo_name)
+                except UnknownObjectException:
+                    continue
+                stars = repo.watchers
+                forks = repo.forks
+                elem['stars'] = stars
+                elem['forks'] = forks
+                print('{}/{} {} -- {} stars, {} forks'.format(i+1, len(data), repo_name, stars, forks))
+            else:
+                print('{}/{} skipping {}'.format(i+1, len(data), elem['url']))
+        except Exception as bad_data_entry:
+            print(f"elem: {elem}")
+            raise bad_data_entry
 
     with open(args.file, 'w') as fout:
         yaml.dump(data, fout, indent=2, width=80)


### PR DESCRIPTION
# Description

## star updater
- Make `script/update-star-count.py` print malformed data entries so we can tell what data file needs fixing.
- Have separate `run` stepts to make it easier to tell exactly which `yaml` file is bad

## build
- Ignore errors for reddit & twitter urls
  - reddit is 404ing legit subreddit urls, probably to keep the AI idiots from scraping them for training data
  - twitter is a shitshow, don't let their breakage affect our builds

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.
