### PR TITLE
Fix star count updating and update URLs of moved repos

### DIFF
--- a/_data/bootstrap.yml
+++ b/_data/bootstrap.yml
@@ -1,20 +1,20 @@
-- forks: 1884
+- forks: 1895
   name: thoughtbot/dotfiles
   notes: A base set of configs, plugins, scripts, and aliases for vim, tmux, git,
     ruby, and zsh.
-  stars: 7771
+  stars: 7840
   url: https://github.com/thoughtbot/dotfiles
-- forks: 379
+- forks: 383
   name: dotphiles
   notes: A community driven framework of dotfiles, for the usual terminal apps and
     shells, designed to work across multiple platforms and degrade for older versions
     of software or OS, allowing you to use the same settings on all your machines.
-  stars: 772
+  stars: 774
   url: https://github.com/dotphiles/dotphiles
-- forks: 19
+- forks: 22
   name: Dorothy
   notes: Bring your dotfile commands and configuration to any shell. Sensible defaults
     and hundreds of commands preloaded. Supports Bash, Zsh, Fish, Nu, Xonsh, Elvish,
     Dash, KornShell, macOS, Linux, Windows.
-  stars: 173
+  stars: 207
   url: https://github.com/bevry/dorothy

--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -1,15 +1,15 @@
 - category: Shell
-  forks: 434
+  forks: 433
   name: Liquid Prompt
   notes: is a full-featured and carefully designed adaptive prompt for Bash and ZSH.
-  stars: 4328
+  stars: 4362
   url: https://github.com/liquidprompt/liquidprompt
 - category: Shell
-  forks: 1593
+  forks: 1689
   name: Starship Prompt
   notes: is a context-aware and highly customizable prompt for any shell. Has out-of-the-box
     support for Bash, Fish, PowerShell, Zsh, and more.
-  stars: 37124
+  stars: 38872
   url: https://github.com/starship/starship
 - category: Shell
   forks: 3
@@ -20,31 +20,31 @@
   stars: 21
   url: https://github.com/abourdon/shprofile
 - category: Shell
-  forks: 2331
+  forks: 2348
   name: bash-it
   notes: is a "shameless ripoff of oh-my-zsh," but for bash.
-  stars: 13784
+  stars: 13907
   subcategory: Bash
   url: https://github.com/Bash-it/bash-it
 - category: Shell
-  forks: 265
+  forks: 270
   name: Fisher
   notes: is a package manager for the [fish shell](https://fishshell.com).
-  stars: 6977
+  stars: 7190
   subcategory: Fish
   url: https://github.com/jorgebucaran/fisher
 - category: Shell
-  forks: 850
+  forks: 851
   name: Oh My Fish
   notes: is a fish-shell framework inspired by oh-my-zsh.
-  stars: 9781
+  stars: 9971
   subcategory: Fish
   url: https://github.com/oh-my-fish/oh-my-fish
 - category: Shell
-  forks: 64
+  forks: 65
   name: Antibody
   notes: is a shell plugin manager made from the ground up thinking about performance.
-  stars: 1687
+  stars: 1688
   subcategory: ZSH
   url: https://github.com/getantibody/antibody
 - category: Shell
@@ -58,13 +58,13 @@
   subcategory: ZSH
   url: https://github.com/Tarrasch/antigen-hs
 - category: Shell
-  forks: 296
+  forks: 298
   name: antigen
   notes: is a framework for using plugins and themes in your ZSH configuration. It
     will automatically clone repositories containing the plugins you're using without
     you having to manually create submodules or clones, and supports using [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
     plugins and themes as well as ones published as separate repositories.
-  stars: 7738
+  stars: 7819
   subcategory: ZSH
   url: https://github.com/zsh-users/antigen
 - category: Shell
@@ -74,32 +74,32 @@
     lost when running under older versions of ZSH, but it should degrade cleanly and
     allow you to use the same setup on multiple machines of differing OS's without
     problems.
-  stars: 220
+  stars: 223
   subcategory: ZSH
   url: https://github.com/dotphiles/dotzsh
 - category: Shell
-  forks: 25632
+  forks: 25816
   name: oh-my-zsh
   notes: is a community-driven framework for managing your ZSH configuration. It bundles
     40+ plugins and 80+ themes.
-  stars: 163753
+  stars: 166258
   subcategory: ZSH
   url: https://github.com/ohmyzsh/ohmyzsh
 - category: Shell
-  forks: 4499
+  forks: 4505
   name: Prezto
   notes: is a configuration framework for ZSH. It's a lightweight alternative to oh-my-zsh
     with sane defaults, aliases, functions, auto completion, prompt themes and dozens
     of well documented modules.
-  stars: 13579
+  stars: 13702
   subcategory: ZSH
   url: https://github.com/sorin-ionescu/prezto
 - category: Shell
-  forks: 21
+  forks: 20
   name: slimzsh
   notes: is a small starter framework for ZSH that features the pure prompt, syntax
     highlighting and tab completion.
-  stars: 592
+  stars: 597
   subcategory: ZSH
   url: https://github.com/changs/slimzsh
 - category: Shell
@@ -111,7 +111,7 @@
   subcategory: ZSH
   url: https://github.com/CosmicToast/toasty-zsh
 - category: Shell
-  forks: 11
+  forks: 10
   name: zgenom
   notes: is a lightweight plugin manager for ZSH that is a superset of zgen. It provides
     simple commands for managing plugins. It clones and installs your plugins and
@@ -123,11 +123,11 @@
     it lets us have a minimal overhead when starting up the shell because nobody likes
     waiting. Zgenom can use [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
     and [Prezto](https://github.com/sorin-ionescu/prezto) compliant plugins and themes.
-  stars: 299
+  stars: 313
   subcategory: ZSH
   url: https://github.com/jandamm/zgenom
 - category: Shell
-  forks: 103
+  forks: 104
   name: zgen
   notes: is a lightweight plugin manager for ZSH inspired by Antigen. The goal is
     to have a minimal overhead when starting up the shell because nobody likes waiting.
@@ -136,41 +136,41 @@
     and [Prezto](https://github.com/sorin-ionescu/prezto) compliant plugins and themes.
     zgen is no longer being maintained, we recommend switching to use the [zgenom](https://github.com/jandamm/zgenom)
     fork.
-  stars: 1457
+  stars: 1467
   subcategory: ZSH
   url: https://github.com/tarjoilija/zgen
 - category: Shell
-  forks: 235
+  forks: 236
   name: zplug
   notes: is a next-generation plugin manager for ZSH. There is more to a ZSH plugin
     manager than increasing its speed. Also, there is nothing that zplug cannnot do.
-  stars: 5562
+  stars: 5625
   subcategory: ZSH
   url: https://github.com/zplug/zplug
 - category: Shell
-  forks: 522
+  forks: 531
   name: awesome-zsh-plugins
   notes: is a list of ZSH plugins, themes and completions compatible with Zsh frameworks
     like [antigen](https://github.com/zsh-users/antigen), [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
     and [zgenom](https://github.com/jandamm/zgenom).
-  stars: 13605
+  stars: 13988
   subcategory: ZSH
   url: https://github.com/unixorn/awesome-zsh-plugins
 - category: Shell
-  forks: 90
+  forks: 91
   name: zsh-quickstart-kit
   notes: A quickstart for ZSH and zgenom. It includes a [zgenom](https://github.com/jandamm/zgenom)
     setup, a starter list of plugins, the [zsh-users/zsh-completions](https://github.com/zsh-users/zsh-completions)
     collection, and the [powerlevel10k](https://github.com/romkatv/powerlevel10k)
     theme.
-  stars: 686
+  stars: 713
   subcategory: ZSH
   url: https://github.com/unixorn/zsh-quickstart-kit
 - category: Editors
   forks: 149
   name: Cask
   notes: is a package manager for Emacs.
-  stars: 1251
+  stars: 1254
   subcategory: Emacs
   url: https://github.com/cask/cask
 - category: Editors
@@ -178,113 +178,115 @@
   name: Prelude
   notes: is an enhanced Emacs 24 distribution that should make your experience with
     Emacs both more pleasant and more powerful.
-  stars: 5019
+  stars: 5043
   subcategory: Emacs
   url: https://github.com/bbatsov/prelude
 - category: Editors
-  forks: 2992
+  forks: 3013
   name: Doom Emacs
   notes: is an Emacs framework for the stubborn martian hacker.
-  stars: 17674
+  stars: 18123
   subcategory: Emacs
   url: https://github.com/doomemacs/doomemacs
 - category: Editors
-  forks: 4957
+  forks: 4972
   name: Spacemacs
   notes: is a Emacs 24 distribution that builds on Evil-mode with ports of popular
     Vim plugins to closer emulate a Vim environment.
-  stars: 23270
+  stars: 23364
   subcategory: Emacs
   url: https://github.com/syl20bnr/spacemacs
 - category: Editors
-  forks: 261
+  forks: 263
   name: use-package
   notes: is a declaration macro for simplifying your `.emacs`
-  stars: 4305
+  stars: 4328
   subcategory: Emacs
   url: https://github.com/jwiegley/use-package
 - category: Editors
   forks: 51
   name: dotvim
   notes: is a community driven framework for vim.
-  stars: 145
+  stars: 147
   subcategory: Vim
   url: https://github.com/dotphiles/dotvim
 - category: Editors
-  forks: 826
+  forks: 825
   name: Janus
   notes: is a distribution of plugins and mappings for Vim, Gvim and MacVim.
-  stars: 7875
+  stars: 7878
   subcategory: Vim
   url: https://github.com/carlhuda/janus
 - category: Editors
   forks: 168
   name: Neobundle
   notes: is a next generation Vim plugin manager.
-  stars: 2300
+  stars: 2296
   subcategory: Vim
   url: https://github.com/Shougo/neobundle.vim
 - category: Editors
-  forks: 1202
+  forks: 1198
   name: Pathogen
   notes: is a plugin manager for Vim.
-  stars: 12051
+  stars: 12071
   subcategory: Vim
   url: https://github.com/tpope/vim-pathogen
 - category: Editors
-  forks: 3702
+  forks: 3690
   name: spf13-vim
   notes: is Steve Francia's Vim distribution of vim plugins and resources for Vim,
     Gvim and MacVim.
-  stars: 15517
+  stars: 15536
   subcategory: Vim
   url: https://github.com/spf13/spf13-vim
 - category: Editors
-  forks: 1922
+  forks: 1933
   name: vim-plug
   notes: is a simple plugin manager that supports parallel installations / upgrades.
-  stars: 32234
+  stars: 32699
   subcategory: Vim
   url: https://github.com/junegunn/vim-plug
 - category: Editors
-  forks: 2600
+  forks: 2620
   name: Vundle
   notes: is short for _Vim Bundle_ and is a plugin manager for Vim. It works with
     Pathogen compatible vim plugins.
-  stars: 23645
+  stars: 23755
   subcategory: Vim
   url: https://github.com/VundleVim/Vundle.vim
 - category: Shell
-  forks: 16
+  forks: 21
   name: sheldon
   notes: A fast, configurable, shell plugin manager
-  stars: 770
+  stars: 866
   url: https://github.com/rossmacarthur/sheldon
 - category: Editors
-  forks: 193
+  forks: 234
   name: lazy.nvim
   notes: is a modern plugin manager for Neovim.
-  stars: 7979
+  stars: 9749
   subcategory: Neovim
   url: https://github.com/folke/lazy.nvim
 - category: Editors
-  forks: 262
+  forks: 266
   name: packer.nvim
   notes: is a plugin manager. It supports Luarocks dependencies and uses native packages.
-  stars: 7169
+  stars: 7393
   subcategory: Neovim
   url: https://github.com/wbthomason/packer.nvim
 - category: Editors
-  forks: 1654
+  forks: 1882
   name: NvChad
-  notes: is a Neovim distribution focused on speed and good defaults, with a beautiful UI.
-  stars: 19967
+  notes: is a Neovim distribution focused on speed and good defaults, with a beautiful
+    UI.
+  stars: 21406
   subcategory: Neovim
   url: https://github.com/NvChad/NvChad
 - category: Editors
-  forks: 1502
+  forks: 1499
   name: LunarVim
-  notes: is another Neovim distribution, geared towards building a community-driven IDE layer.
-  stars: 16271
+  notes: is another Neovim distribution, geared towards building a community-driven
+    IDE layer.
+  stars: 16893
   subcategory: Neovim
   url: https://github.com/LunarVim/LunarVim

--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -3,7 +3,7 @@
   name: Liquid Prompt
   notes: is a full-featured and carefully designed adaptive prompt for Bash and ZSH.
   stars: 4328
-  url: https://github.com/nojhan/liquidprompt
+  url: https://github.com/liquidprompt/liquidprompt
 - category: Shell
   forks: 1593
   name: Starship Prompt
@@ -84,7 +84,7 @@
     40+ plugins and 80+ themes.
   stars: 163753
   subcategory: ZSH
-  url: https://github.com/robbyrussell/oh-my-zsh
+  url: https://github.com/ohmyzsh/ohmyzsh
 - category: Shell
   forks: 4499
   name: Prezto
@@ -109,7 +109,7 @@
     a "sane defaults" set for any ZSH config and is optimized for system-wide installation
   stars: 11
   subcategory: ZSH
-  url: https://github.com/5paceToast/toasty-zsh
+  url: https://github.com/CosmicToast/toasty-zsh
 - category: Shell
   forks: 11
   name: zgenom
@@ -187,7 +187,7 @@
   notes: is an Emacs framework for the stubborn martian hacker.
   stars: 17674
   subcategory: Emacs
-  url: https://github.com/hlissner/doom-emacs
+  url: https://github.com/doomemacs/doomemacs
 - category: Editors
   forks: 4957
   name: Spacemacs

--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -288,4 +288,3 @@
   stars: 16271
   subcategory: Neovim
   url: https://github.com/LunarVim/LunarVim
-- category: Editors

--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -1,13 +1,14 @@
 - name: Abdullah
   stars: 7
   url: https://gitlab.com/Abdullah/cfg.git
-- forks: 19
+- forks: 20
   name: 2KAbhishek
   notes: Passionately crafted, extensible dotfiles with extensions for multuple platforms
     ([Windows](https://github.com/2kabhishek/win2k), [MacOS](https://github.com/2kabhishek/mac2k),
     [Android](https://github.com/2kabhishek/termux2k)), editors ([neovim](https://github.com/2kabhishek/nvim2k)),
-    window managers ([sway](https://github.com/2kabhishek/sway2k), [awesome](https://github.com/2kabhishek/awesome2k)) and more.
-  stars: 186
+    window managers ([sway](https://github.com/2kabhishek/sway2k), [awesome](https://github.com/2kabhishek/awesome2k))
+    and more.
+  stars: 191
   url: https://github.com/2kabhishek/dots2k
 - forks: 3
   name: Ace Cassidy
@@ -15,16 +16,16 @@
     allow holding capslock to turn hjkl into arrow keys in any application.
   stars: 16
   url: https://github.com/Ace-Cassidy/dotfiles
-- forks: 465
+- forks: 467
   name: Adam Eivy
   notes: are focused on Automation (no manual install/config) for ZSH and macOS with
     a friendly bot to guide your way.
-  stars: 1317
+  stars: 1321
   url: https://github.com/atomantic/dotfiles
 - forks: 3
   name: aeolyus
   notes: simple dotfiles managed with GNU stow
-  stars: 65
+  stars: 68
   url: https://github.com/aeolyus/dotfiles
 - forks: 4
   name: Alexandros Kozak
@@ -33,13 +34,13 @@
     whichever dotfiles are appropriate for shells and for software installed on any
     system, and running the `update_dotfiles` function in any POSIX-compliant shell
     will keep the dotfiles up to date.
-  stars: 36
+  stars: 38
   url: https://github.com/agkozak/dotfiles
 - forks: 6
   name: Alexey Nikiforov
   notes: facilitates development with WSL + ZSH. Installs major dependencies and handy
     tools for .NET developer.
-  stars: 36
+  stars: 37
   url: https://github.com/nikiforovall/dotfiles
 - forks: 5
   name: Alex Kramer
@@ -48,7 +49,7 @@
     and fancy bash prompt built for legibility and speed with timestamp, path, current
     git branch/status, and bonus pizza! Readme also includes install instructions
     for vim plugins and setup for OSX/macOS fresh install.
-  stars: 13
+  stars: 14
   url: https://github.com/mitochondrion/dotfiles
 - forks: 3
   name: Anders Ballegaard
@@ -56,16 +57,16 @@
     Oh and it updates automatically
   stars: 4
   url: https://github.com/AndersBallegaard/dotfiles
-- forks: 21
+- forks: 22
   name: Andrew Liu
   notes: combines configs for zsh, vim, and tmux with customizations such as [airline](https://github.com/vim-airline/vim-airline)
     for vim and the [Powerlevel10k](https://github.com/romkatv/powerlevel10k) zsh
     theme. Includes custom font glyphs and optional [fzf](https://github.com/junegunn/fzf)/[ripgrep](https://github.com/BurntSushi/ripgrep)
     support in vim. A [one-liner](https://github.com/MrPickles/dotfiles#installation)
     installation script comes as part of the package.
-  stars: 31
+  stars: 33
   url: https://github.com/MrPickles/dotfiles
-- forks: 12
+- forks: 11
   name: Andrew Schwartzmeyer
   notes: use GNU Stow (like xero's) for symlink management, and `git-subtree` for
     repository integration.
@@ -77,10 +78,10 @@
     node, python, vim, vscode and zsh amongst others. Read more on [his blog](https://angelo.dini.dev/blog/dotfiles/).
   stars: 13
   url: https://github.com/FinalAngel/dotfiles
-- forks: 50
+- forks: 51
   name: Artem Sapegin
   notes: with custom ZSH and Terminal/iTerm themes and useful aliases for web developers.
-  stars: 465
+  stars: 467
   url: https://github.com/sapegin/dotfiles
 - forks: 17
   name: Ashish Bhatia
@@ -88,7 +89,7 @@
     currencies) development on macOS.
   stars: 80
   url: https://github.com/ashishb/dotfiles
-- forks: 513
+- forks: 515
   name: Ben Alman
   notes: support different configurations per OS, linking, copying and environment
     setup.
@@ -101,7 +102,7 @@
     color scheme and aliases for [Zeek NSM](https://www.zeek.org/).
   stars: 18
   url: https://github.com/bndabbs/dotfiles
-- forks: 8
+- forks: 7
   name: Cristian PB
   notes: i3, polybar, mbsync, mutt, ranger, nvim dotfiles installed using stow.
   stars: 26
@@ -110,24 +111,24 @@
   name: Darryl Abbate
   notes: can be installed with a [single curl command](https://github.com/rootbeersoup/get.darryl.sh)
     for absolutely effortless setup on a fresh macOS machine.
-  stars: 65
+  stars: 67
   url: https://github.com/rootbeersoup/dotfiles
 - forks: 189
   name: Diki Ananta
   notes: is focused on Window Manager users, especially for [i3](https://github.com/i3/i3),
     and Web developers. It has various configs for standard of window manager.
-  stars: 1354
+  stars: 1371
   url: https://github.com/dikiaap/dotfiles
-- forks: 671
+- forks: 684
   name: Dries Vints
   notes: leverages [Brew](https://github.com/driesvints/dotfiles/blob/master/Brewfile)
     and [mackup](https://github.com/lra/mackup) to setup an entire macOS environment.
-  stars: 1972
+  stars: 2038
   url: https://github.com/driesvints/dotfiles
 - forks: 80
   name: Eduardo Lundgren
   notes: are the first JavaScript-based dotfiles powered by Grunt.
-  stars: 422
+  stars: 423
   url: https://github.com/eduardolundgren/dotfiles
 - forks: 5
   name: Felix Volny
@@ -140,7 +141,7 @@
   notes: is a lightweight yet powerful dotfiles for MacOS users. It uses GNU Stow
     to manage the symlinks, ZSH as the shell environment and Nvim + Tmux for the coding
     (along with other useful tools).
-  stars: 116
+  stars: 118
   url: https://github.com/huyvohcmc/dotfiles
 - forks: 88
   name: Ian Langworth
@@ -148,13 +149,13 @@
     hosts. With plenty of useful shell aliases and command defaults, it features [a
     simple install script](https://github.com/statico/dotfiles/blob/master/install.zsh)
     to install itself and stay up-to-date.
-  stars: 680
+  stars: 684
   url: https://github.com/statico/dotfiles
 - forks: 23
   name: Kraymer
   notes: is an opinionated dotfiles organization scheme based on GNU Stow. Highest
     priorities are ease of maintenance and deployment on both Linux and macOS.
-  stars: 164
+  stars: 165
   url: https://github.com/Kraymer/F-dotfiles
 - forks: 17
   name: Jeff Coffler
@@ -162,7 +163,7 @@
     in the repo. The repo itself can live anywhere.
   stars: 34
   url: https://github.com/jeffaco/dotfiles
-- forks: 59
+- forks: 57
   name: Jonas Devlieghere
   notes: for both macOS and Linux has a little bit of everything for compiler development
     in the terminal.
@@ -189,7 +190,7 @@
   name: kutsan
   notes: includes ongoing configuration files for various interfaces and text-based
     command-line applications such as vim, ZSH, tmux, ranger, mutt, newsboat and more.
-  stars: 332
+  stars: 333
   url: https://github.com/kutsan/dotfiles
 - forks: 4
   name: matBRGZ
@@ -197,19 +198,19 @@
     |  Lastest Ubuntu & Windows & WSL2
   stars: 13
   url: https://github.com/matheusrv/dotfiles
-- forks: 8811
+- forks: 8814
   name: Mathias Bynens
   notes: includes a bootstrap script that rsyncs your repo to your home folder. Mathias'
     [macOS defaults script](https://github.com/mathiasbynens/dotfiles/blob/master/.macos)
     is legendary.
-  stars: 29393
+  stars: 29587
   url: https://github.com/mathiasbynens/dotfiles
 - forks: 12
   name: Matt Smith
   notes: includes a one-liner install, fish, vscode, mac desktop app installs via
     brew cask, os x customizations inspired by Mathias, etc.  No dotfiles framework,
     just shell scripts to set everything up.
-  stars: 85
+  stars: 87
   url: https://github.com/mattorb/dotfiles
 - forks: 9
   name: mihaliak
@@ -219,33 +220,33 @@
 - forks: 3
   name: Mohit Singh
   notes: has a lightweight setup for JavaScript development environment on macOS.
-  stars: 8
+  stars: 7
   url: https://github.com/mohitsinghs/dotfiles
 - forks: 12
   name: neeasade
   notes: utilize a template based theming system, with the ability to switch between
     themes without restarting programs.
-  stars: 379
+  stars: 381
   url: https://github.com/neeasade/dotfiles
 - forks: 16
   name: "Nelson Estev\xE3o"
   notes: uses a modular repository structure. It features configuration files for
     popular software like neovim, ZSH and i3wm. Just delete the directories that you
     are not interested and run `install.sh`.
-  stars: 97
+  stars: 99
   url: https://github.com/nelsonmestevao/dotfiles
-- forks: 95
+- forks: 93
   name: Nick Plekhanov
   notes: features properly customized ZSH and iTerm environments, along with Atom
     editor and Webstorm IDE. As a bonus, included is a set of useful aliases for web
     developers.
-  stars: 326
+  stars: 325
   url: https://github.com/nicksp/dotfiles
-- forks: 88
+- forks: 90
   name: Nikita Sobolev
   notes: contains Python, Node, and Elixir configurations for macOS alongside with
     the most user-friendly command line tools for the developer happiness.
-  stars: 629
+  stars: 641
   url: https://github.com/sobolevn/dotfiles
 - forks: 6
   name: Overbryd
@@ -253,18 +254,18 @@
     Makefile
   stars: 40
   url: https://github.com/Overbryd/dotfiles
-- forks: 189
+- forks: 187
   name: Paul Miller
   notes: feature greatly customized ZSH with auto-completion and syntax highlighting,
     a bunch of useful Git extras and colourful themes for macOS Terminal and Sublime
     Text.
-  stars: 1180
+  stars: 1178
   url: https://github.com/paulmillr/dotfiles
 - forks: 19
   name: posquit0
   notes: contains awesome configurations for CLI commands and X environments, along
     with powerfully customized Vim, ZSH and Tmux environments for nerds.
-  stars: 175
+  stars: 182
   url: https://github.com/posquit0/dotfiles
 - forks: 4
   name: ridhwaans
@@ -276,32 +277,32 @@
   name: Rosco Kalis
   notes: feature Fish shell configuration with custom completions, as well as comprehensive
     package management, repository management and Hammerspoon configuration.
-  stars: 230
+  stars: 233
   url: https://github.com/rkalis/dotfiles
 - forks: 51
   name: Voku
   notes: dotfiles for Bash (Linux) / ZSH (Linux) / Git Bash (Windows) / Cygwin (Windows)
     / Bash on Ubuntu on Windows.
-  stars: 212
+  stars: 213
   url: https://github.com/voku/dotfiles
 - forks: 115
   name: xero
   notes: are managed with [GNU Stow](https://www.gnu.org/software/stow/), a free,
     portable, lightweight symlink farm manager.
-  stars: 1810
+  stars: 1855
   url: https://github.com/xero/dotfiles
-- forks: 1440
+- forks: 1432
   name: Yan Pritzker
   notes: bundles an opinionated set of Vim plugins and ZSH setup all tuned for using
     [Solarized](https://github.com/altercation/solarized) on macOS.
-  stars: 6921
+  stars: 6931
   url: https://github.com/skwp/dotfiles
-- forks: 3364
+- forks: 3366
   name: Zach Holman
   notes: features topical organization, auto sourcing ZSH files, easy ZSH completion
     extensions, and a local bin folder for executables. The included `Rakefile` will
     symlink anything ending in `.symlink` to your `~` folder,
-  stars: 7003
+  stars: 7073
   url: https://github.com/holman/dotfiles
 - forks: 0
   name: Kamil Zabielski
@@ -317,12 +318,12 @@
     development environment.
   stars: 36
   url: https://github.com/adityarpillai/jumpstart
-- forks: 8
+- forks: 9
   name: Jogendra
   notes: contains freshly brewed configuration files for various CLI applications
     based on macOS. With plenty of useful shell/Git aliases, shell scripts, AppleScripts
     and command defaults, it features beautifully customised ZSH and iTerm2 environments.
-  stars: 66
+  stars: 69
   url: https://github.com/jogendra/dotfiles
 - forks: 3
   name: Roger Oba
@@ -336,7 +337,7 @@
     written in Ansible that installs and configures effortlessly multiple command
     line and grapical interface applications on macOS & Linux as well as a lightweight
     ZSH config using a custom "no-framework" approach.
-  stars: 13
+  stars: 14
   url: https://github.com/mateusrevoredo/dotfiles
 - forks: 1
   name: Kyle Westhaus
@@ -348,14 +349,14 @@
   name: TED Vortex
   notes: A utility first dev tooling repo with dotbot, zsh, antibody, defaults, plist,
     fonts, git-extras, atom, pip, npm, cargo, go, karabiner, carpalx full optimisation.
-  stars: 15
+  stars: 14
   url: https://github.com/0-vortex/dotfiles
-- forks: 158
+- forks: 159
   name: owl4ce
   notes: Aesthetic OpenboxWM Environment. The complete setup, including configuration
     of several apps and shell scripting allows things to change with just one click
     and from the variables.
-  stars: 1879
+  stars: 1929
   url: https://github.com/owl4ce/dotfiles
 - forks: 1
   name: Thuan Pham
@@ -365,25 +366,25 @@
 - forks: 0
   name: exshak
   notes: Custom configs for macOS & Linux ~ brew, osx, tmux, vim, zsh, bash.
-  stars: 8
+  stars: 9
   url: https://github.com/exshak/dotfiles
 - forks: 14
   name: BachoSeven
   notes: Minimal dwm setup with batteries included - from a functional and mouse-friendly
     status bar using POSIX-compliant scripts to a powerful zsh configuration with
     vim-like bindings and custom plugins.
-  stars: 141
+  stars: 145
   url: https://github.com/BachoSeven/dotfiles
 - forks: 5
   name: g6ai
   notes: My dotfiles for Bash/Zsh, Vim/Neovim, Doom Emacs, tmux, Git, terminal emulators,
     JupyterLab, aria2 and mpv
-  stars: 198
+  stars: 201
   url: https://github.com/g6ai/dotfiles
-- forks: 21
+- forks: 20
   name: twpayne
   notes: Dotfiles, managed with https://github.com/twpayne/chezmoi.
-  stars: 222
+  stars: 231
   url: https://github.com/twpayne/dotfiles
 - forks: 5
   name: ayoisaiah
@@ -391,31 +392,31 @@
     and Neovim.
   stars: 82
   url: https://github.com/ayoisaiah/dotfiles
-- forks: 21
+- forks: 20
   name: renemarc
   notes: "~/. Cross-platform, cross-shell configuration files. \u2699\uFE0F\U0001F4BB"
-  stars: 159
+  stars: 168
   url: https://github.com/renemarc/dotfiles
 - forks: 4
   name: benmezger
   notes: My collection of dotfiles
-  stars: 95
+  stars: 98
   url: https://github.com/benmezger/dotfiles
 - forks: 35
   name: felipecrs
   notes: Bootstrap your Ubuntu in a few minutes!
-  stars: 215
+  stars: 228
   url: https://github.com/felipecrs/dotfiles
-- forks: 11
+- forks: 12
   name: szorfein
   notes: Use chezmoi to install my dotfiles easily on Gentoo, Arch, Void and Debian.
-  stars: 93
+  stars: 101
   url: https://github.com/szorfein/dots
-- forks: 20
+- forks: 19
   name: narze
   notes: macOS / Codespaces dotfiles with 1-line setup script. Tested on Apple Silicon
     Macs. Supports both zsh and fish. Now managed with https://github.com/twpayne/chezmoi
-  stars: 113
+  stars: 120
   url: https://github.com/narze/dotfiles
 - forks: 12
   name: rafamadriz
@@ -427,18 +428,18 @@
   notes: 'is a setup based on Makefiles and git submodules. Highlights: documented
     xmonad setup, concurrent systemd-based X11 sessions, tons of useful tiny shell
     scripts and vim plugins.'
-  stars: 89
+  stars: 90
   url: https://github.com/liskin/dotfiles
 - forks: 4
   name: frdmn
   notes: Well-maintained dotfile setup for macOS workstations based on Ansible.
-  stars: 25
+  stars: 26
   url: https://github.com/frdmn/dotfiles
-- forks: 220
+- forks: 225
   name: webpro
   notes: Dotfiles for macOS. Makefile and Homebrew-based installation, up-to-date
     and well-organized, weekly tested.
-  stars: 1008
+  stars: 1024
   url: https://github.com/webpro/dotfiles
 - forks: 3
   name: Neos21
@@ -457,11 +458,11 @@
     etc.
   stars: 29
   url: https://github.com/cvuorinen/dotfiles
-- forks: 40
+- forks: 41
   name: yutkat
   notes: My dotfiles containing settings for Neovim, zsh, wezterm and sway working
     on Arch/Ubuntu/Fedora Linux. Using CI to test and measure startup speed.
-  stars: 548
+  stars: 605
   url: https://github.com/yutkat/dotfiles
 - forks: 0
   name: codingjerk

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -2,21 +2,21 @@
   name: kody
   notes: is a dotfiles runner/manager written with node inspired by Zach Holman's
     popular dotfiles.
-  stars: 135
+  stars: 137
   url: https://github.com/jh3y/kody
 - forks: 13
   name: bashdot
   notes: is a minimalist dotfile management framework, written 100% in bash.
-  stars: 98
+  stars: 97
   url: https://github.com/bashdot/bashdot
-- forks: 451
+- forks: 467
   name: chezmoi
   notes: makes it easy to manage your dotfiles across multiple machines, securely.
     chezmoi is [easy to install](https://chezmoi.io/install/), [quick to start with](https://chezmoi.io/quick-start/),
     and is [very powerful](https://www.chezmoi.io/user-guide/setup/). You can install
     chezmoi and your dotfiles with a single command, without needing Python installed,
     or even git. Read how [chezmoi compares to other dotfile managers](https://www.chezmoi.io/comparison-table/).
-  stars: 10227
+  stars: 10838
   url: https://github.com/twpayne/chezmoi
   website: https://chezmoi.io
 - forks: 3
@@ -30,36 +30,36 @@
   notes: is a dotfile manager that has no configuration, one-command importing, one-command
     syncing, multiple repository support, automatic cleanup, and can be used with
     git or any other RCS.
-  stars: 62
+  stars: 64
   url: https://github.com/CGamesPlay/dfm
 - forks: 3
   name: Config Curator
   notes: defines your dotfile installation in a simple but powerful config file. Sync
     files, directories, and symlinks across multiple environments with this ludicrous-speed
     Node.js successor to the original [Ruby version](https://github.com/razor-x/config_curator).
-  stars: 31
+  stars: 30
   url: https://github.com/razor-x/config-curator
 - forks: 18
   name: dfm
   notes: is a utility to manage your dotfiles, lightweight and simple.
   stars: 118
   url: https://github.com/justone/dfm
-- forks: 285
+- forks: 286
   name: Dotbot
   notes: is a lightweight standalone tool to bootstrap dotfiles, making it easy to
     have a "one click" installation/upgrade process for your dotfiles.
-  stars: 6485
+  stars: 6637
   url: https://github.com/anishathalye/dotbot
-- forks: 104
+- forks: 105
   name: dotdrop
   notes: Save your dotfiles once, deploy them everywhere.
-  stars: 1682
+  stars: 1712
   url: https://github.com/deadc0de6/dotdrop
 - forks: 31
   name: dotfiler
   notes: is inspired by homesick and [Zach Holman's dotfiles](https://github.com/holman/dotfiles),
     made using principle of KISS.
-  stars: 238
+  stars: 237
   url: https://github.com/svetlyak40wt/dotfiler
 - forks: 11
   name: dotfiles.sh
@@ -68,7 +68,7 @@
     locally patching your dotfiles before symlinking to adapt to the local machine.
     Dotfile repositories may be fetched via either Git or (where Git is not available)
     wget.
-  stars: 63
+  stars: 62
   url: https://github.com/wking/dotfiles-framework
 - forks: 12
   name: dotgit
@@ -91,11 +91,11 @@
     for multiple environments. It also supports shell autocompletion.
   stars: 97
   url: https://github.com/clayrisser/dotstow
-- forks: 65
+- forks: 66
   name: Dotsync
   notes: utility for syncing dotfiles between multiple machines from a Git repo or
     push using rsync.
-  stars: 308
+  stars: 315
   url: https://github.com/dotphiles/dotsync
 - forks: 15
   name: dotty
@@ -107,7 +107,7 @@
 - forks: 29
   name: Ellipsis
   notes: is a package manager for dotfiles.
-  stars: 352
+  stars: 350
   url: https://github.com/ellipsis/ellipsis
 - forks: 8
   name: exogenesis
@@ -120,7 +120,7 @@
   notes: is a tool to source dotfiles from others into your own. It supports shell
     configuration (aliases, functions, etc.) as well as config files (e.g. `ackrc`
     and `gitconfig`). Think of it as _Bundler for your dotfiles_.
-  stars: 1161
+  stars: 1167
   url: https://github.com/freshshell/fresh
 - forks: 37
   name: Ghar
@@ -140,27 +140,27 @@
     you. Homely also has a clever Automatic Cleanup feature and good tutorials.
   stars: 45
   url: https://github.com/phodge/homely
-- forks: 1414
+- forks: 1488
   name: Home Manager
   notes: by Robert Helgesson is a system built for managing [NixOS](https://nixos.org)
     user environments using the [Nix](https://nixos.org/nix/) package manager and
     the [Nixpkgs](https://nixos.org/nixpkgs/) libraries.
-  stars: 4920
+  stars: 5340
   url: https://github.com/nix-community/home-manager
-- forks: 26
+- forks: 25
   name: Homemaker
   notes: by Alex Yatskov. Homemaker is a standalone tool written in Golang to manage
     both common and machine-specific dotfile settings. Homemaker can be configured
     in TOML, YAML or JSON.
-  stars: 234
+  stars: 235
   url: https://github.com/FooSoft/homemaker
-- forks: 150
+- forks: 149
   name: Homeshick
   notes: by Anders Ingemann is like Homesick but written in bash. Great to combine
     with [myrepos](https://web.archive.org/web/20200904205236/https://waiting-for-dev.github.io/blog/2014/05/04/distributable-and-organized-dotfiles-with-homeshick-and-mr/).
-  stars: 2005
+  stars: 2026
   url: https://github.com/andsens/homeshick
-- forks: 132
+- forks: 133
   name: Homesick
   notes: by Josh Nichols. Homesick makes it easy to symlink and clone dotfiles repos.
   stars: 2393
@@ -175,25 +175,25 @@
     Dotfiles are treated as packages that coexist together seamlessly and can be fully
     controlled and synced across different systems. There is a wide range of packages
     already available in the [Official Pearl Hub](https://github.com/pearl-hub).
-  stars: 221
+  stars: 225
   url: https://github.com/pearl-core/pearl
-- forks: 133
+- forks: 134
   name: rcm
   notes: is a set of well-documented shell scripts that help manage your dotfiles.
     It is easily installable on macOS with the homebrew package manager, but works
     on all Unix operating systems.
-  stars: 3010
+  stars: 3033
   url: https://github.com/thoughtbot/rcm
-- forks: 244
+- forks: 248
   name: shallow-backup
   notes: lets you easily create lightweight backups of installed packages, applications,
     fonts and dotfiles, and automatically push them to a remote Git repository.
-  stars: 1109
+  stars: 1148
   url: https://github.com/alichtman/shallow-backup
 - forks: 12
   name: stowsh
   notes: is a clone of GNU Stow written in bash with minimal dependencies.
-  stars: 90
+  stars: 89
   url: https://github.com/mikepqr/stowsh
 - name: summon
   notes: is a Bash tool that shares basically the same concept as Stow but with some
@@ -208,14 +208,14 @@
     branches for different systems are supported by default. An extensive hook system
     lets you customize your repositories. `vcsh` includes batch push, pull, and status
     commands which operate on all your repositories at once.
-  stars: 2112
+  stars: 2133
   url: https://github.com/RichiH/vcsh
-- forks: 172
+- forks: 177
   name: yadm
   notes: is a dotfile management tool which supports system-specific alternate files/templating,
     encryption of private data, custom bootstrap actions, and integration with other
     git-aware tools like vim-fugitive, tig, git-crypt, etc.
-  stars: 4390
+  stars: 4551
   url: https://github.com/TheLocehiliosan/yadm
   website: https://yadm.io/
 - forks: 9
@@ -232,28 +232,28 @@
     multiple hosts, supports variable symlink targets and is infinitely hackable.
   stars: 4
   url: https://github.com/igordertigor/yadoma
-- forks: 36
+- forks: 39
   name: dotter
   notes: A dotfile manager and templater written in Rust, with Windows/Linux/Mac support.
-  stars: 647
+  stars: 707
   url: https://github.com/SuperCuber/dotter
-- forks: 64
+- forks: 62
   name: dotfiles
   notes: Dotfile management made easy. Written in Python (available on PyPI) by Jon
     Bernard.
-  stars: 566
+  stars: 568
   url: https://github.com/jbernard/dotfiles
-- forks: 39
+- forks: 43
   name: comtrya
   notes: configuration Management for Localhost / dotfiles.
-  stars: 382
+  stars: 408
   url: https://github.com/comtrya/comtrya
   website: https://www.comtrya.dev/
 - forks: 8
   name: dotfiles
   notes: Dotfiles symbolic links management CLI written in Go, with Windows/Linux/Mac
     support.
-  stars: 209
+  stars: 210
   url: https://github.com/rhysd/dotfiles
 - forks: 0
   name: symly
@@ -267,10 +267,10 @@
     the job (rsync, git, Dropbox, Tresorit, ...)
   stars: 7
   url: https://github.com/loicrouchon/symly
-- forks: 924
+- forks: 935
   name: Mackup
   notes: is an application settings and configuration manager. It automatically finds
     the location of settings files for a set of known applications and syncs them
     with Dropbox, Git, or any other supported method.
-  stars: 13763
+  stars: 13948
   url: https://github.com/lra/mackup

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -38,7 +38,7 @@
     files, directories, and symlinks across multiple environments with this ludicrous-speed
     Node.js successor to the original [Ruby version](https://github.com/razor-x/config_curator).
   stars: 31
-  url: https://github.com/rxrc/curator
+  url: https://github.com/razor-x/config-curator
 - forks: 18
   name: dfm
   notes: is a utility to manage your dotfiles, lightweight and simple.
@@ -90,7 +90,7 @@
     It backups dotfiles with git and keeps track of simultaneous dotfile configurations
     for multiple environments. It also supports shell autocompletion.
   stars: 97
-  url: https://github.com/codejamninja/dotstow
+  url: https://github.com/clayrisser/dotstow
 - forks: 65
   name: Dotsync
   notes: utility for syncing dotfiles between multiple machines from a Git repo or
@@ -146,7 +146,7 @@
     user environments using the [Nix](https://nixos.org/nix/) package manager and
     the [Nixpkgs](https://nixos.org/nixpkgs/) libraries.
   stars: 4920
-  url: https://github.com/rycee/home-manager
+  url: https://github.com/nix-community/home-manager
 - forks: 26
   name: Homemaker
   notes: by Alex Yatskov. Homemaker is a standalone tool written in Golang to manage
@@ -194,7 +194,7 @@
   name: stowsh
   notes: is a clone of GNU Stow written in bash with minimal dependencies.
   stars: 90
-  url: https://github.com/williamsmj/stowsh
+  url: https://github.com/mikepqr/stowsh
 - name: summon
   notes: is a Bash tool that shares basically the same concept as Stow but with some
     key differences that are more suitable to the deploy of dotfiles.
@@ -231,7 +231,7 @@
     YAML as configuration syntax and the pile-of-symlinks approach. It can manage
     multiple hosts, supports variable symlink targets and is infinitely hackable.
   stars: 4
-  url: https://github.com/esc/yadoma
+  url: https://github.com/igordertigor/yadoma
 - forks: 36
   name: dotter
   notes: A dotfile manager and templater written in Rust, with Windows/Linux/Mac support.


### PR DESCRIPTION
The star count updating has been broken since #365. This PR fixes it.

It also updates a few URLs for repos that have moved.

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.


