### PR TITLE
Remove unmaintained and archived Zsh projects

### DIFF
--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -41,23 +41,6 @@
   subcategory: Fish
   url: https://github.com/oh-my-fish/oh-my-fish
 - category: Shell
-  forks: 65
-  name: Antibody
-  notes: is a shell plugin manager made from the ground up thinking about performance.
-  stars: 1688
-  subcategory: ZSH
-  url: https://github.com/getantibody/antibody
-- category: Shell
-  forks: 21
-  name: antigen-hs
-  notes: is an antigen-inspired ZSH plugin manager that tries to do work statically
-    and only on manual invocation, minimizing the ZSH startup time. Antigen-hs is
-    much more minimalistic and emphasizes convention over configuration more strongly
-    than antigen.
-  stars: 205
-  subcategory: ZSH
-  url: https://github.com/Tarrasch/antigen-hs
-- category: Shell
   forks: 297
   name: antigen
   notes: is a framework for using plugins and themes in your ZSH configuration. It
@@ -67,16 +50,6 @@
   stars: 7824
   subcategory: ZSH
   url: https://github.com/zsh-users/antigen
-- category: Shell
-  forks: 37
-  name: dotzsh
-  notes: strives to be platform and version independent, some functionality may be
-    lost when running under older versions of ZSH, but it should degrade cleanly and
-    allow you to use the same setup on multiple machines of differing OS's without
-    problems.
-  stars: 223
-  subcategory: ZSH
-  url: https://github.com/dotphiles/dotzsh
 - category: Shell
   forks: 25821
   name: oh-my-zsh


### PR DESCRIPTION
# Description

As seen by in linked PRs, removed projects either haven't been commited to for 9+ years or are archived and no longer maintained.

There are a lot of entries, so I think it is worth narrowing down less-relevant entries.

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.
