### PR TITLE
Remove `stars` threshold for inspiration (based on guideline)

### DIFF
--- a/inspiration.md
+++ b/inspiration.md
@@ -14,7 +14,6 @@ request](https://github.com/dotfiles/dotfiles.github.com/pulls)!
 <ul>
 {% assign inspiration = site.data.inspiration | sort: 'stars' | reverse %}
 {% for repo in inspiration %}
-{% if repo.stars > 50 %}
 <li><a href="{{ repo.url }}">{{ repo.name }}'s dotfiles</a>{% if repo.notes %} {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}{% endif %}</li>
 {% endif %}
 {% endfor %}

--- a/inspiration.md
+++ b/inspiration.md
@@ -15,6 +15,5 @@ request](https://github.com/dotfiles/dotfiles.github.com/pulls)!
 {% assign inspiration = site.data.inspiration | sort: 'stars' | reverse %}
 {% for repo in inspiration %}
 <li><a href="{{ repo.url }}">{{ repo.name }}'s dotfiles</a>{% if repo.notes %} {{ repo.notes | markdownify | remove: '<p>' | remove: '</p>' }}{% endif %}</li>
-{% endif %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
# Description

Based on the [contribution guideline](https://github.com/dotfiles/dotfiles.github.com/blob/master/CONTRIBUTING.md#notability-criteria) there should not be any threshold based on stars. That's why I think it makes sense to remove it. (or update guideline)

Thanks 😉

> ### Notability criteria
> Inspiration: no criteria, sorted by stars

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.

# Things to look out for in your PR

Make sure that if your `notes` field in any additions/updates you make to the YAML files in the `_data` directory contains any `:` characters that the entire field is quoted as shown below:

Valid:

```yaml
foo: "bar: baz"
```

Invalid:

```yaml
foo: bar: baz
```
