### PR TITLE
Added Multigit

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -274,3 +274,8 @@
     with Dropbox, Git, or any other supported method.
   stars: 14546
   url: https://github.com/lra/mackup
+forks: 18
+  name: multigit
+  notes: allows checking out multiple git repositories overlaid onto the same directory.
+  stars: 145
+  url: https://github.com/capr/multigit


### PR DESCRIPTION
# Description
Multigit allows multiple git repositories to be overlaid in the same directory, useful for projects with separately developed components. Unlike submodules or subtrees, it tracks files from any part of the directory structure, acting like a union filesystem where each repository is a layer.
# Copyright Assignment

-  This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license
