### PR TITLE
Add hideDot utility for dotfiles management

### DIFF
--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -274,3 +274,10 @@
     with Dropbox, Git, or any other supported method.
   stars: 14783
   url: https://github.com/lra/mackup
+- forks: 0
+  name: hideDot
+  notes: is a fast manager for your dotfiles, symlinks, and system configuration
+    with a simple YAML config. Features home directory expansion, git repo cloning,
+    and shell command execution.
+  stars: 3
+  url: https://github.com/youhide/hideDot 


### PR DESCRIPTION
# Description

Introduce the hideDot utility to streamline the management of dotfiles and system configurations using a simple YAML configuration. This utility supports home directory expansion, git repository cloning, and shell command execution.

# Description

# Copyright Assignment

- [ ] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.