### PR TITLE
Add more Neovim distributions

### DIFF
--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -273,10 +273,26 @@
   subcategory: Neovim
   url: https://github.com/NvChad/NvChad
 - category: Editors
+  forks: 1400
+  name: LazyVim
+  notes: is a Neovim distribution for the lazy, focusing on speed, sane defaults
+    and easy customisation.
+  stars: 19900
+  subcategory: Neovim
+  url: https://github.com/LazyVim/LazyVim
+- category: Editors
   forks: 1510
   name: LunarVim
-  notes: is another Neovim distribution, geared towards building a community-driven
+  notes: is a Neovim distribution, geared towards building a community-driven
     IDE layer.
   stars: 18727
   subcategory: Neovim
   url: https://github.com/LunarVim/LunarVim
+- category: Editors
+  forks: 946
+  name: AstroNvim
+  notes: is a Neovim distribution with an aesthetic and feature-rich configuration
+    that is extensible and easy to use with a great set of plugins.
+  stars: 13200
+  subcategory: Neovim
+  url: https://github.com/AstroNvim/AstroNvim

--- a/_data/utilities.yml
+++ b/_data/utilities.yml
@@ -248,6 +248,7 @@
   notes: configuration Management for Localhost / dotfiles.
   stars: 546
   url: https://github.com/comtrya/comtrya
+  website: https://comtrya.dev/
 - forks: 7
   name: dotfiles
   notes: Dotfiles symbolic links management CLI written in Go, with Windows/Linux/Mac


### PR DESCRIPTION
# Description
Add the LazyVim and AstroNvim distributions, which are popular enough to warrant inclusion in this repository.

Also added back the website for Comtrya, as it is online again.

# Copyright Assignment

- [x] This document is covered by the [MIT License](https://github.com/dotfiles/dotfiles.github.com/blob/master/LICENSE.md), and I agree to contribute this PR under the terms of the license.