### PR TITLE
Add eoli3n dotfiles example

### DIFF
--- a/_data/inspiration.yml
+++ b/_data/inspiration.yml
@@ -137,6 +137,13 @@
   notes: are the first JavaScript-based dotfiles powered by Grunt.
   stars: 419
   url: https://github.com/eduardolundgren/dotfiles
+- forks: 70
+  name: eoli3n
+  notes: uses Ansible roles and Jinja templates to manage Sway, fish, Waybar,
+    Neovim, and other dotfiles across local or SSH-connected hosts, with dry-run
+    and diff workflows for safer changes.
+  stars: 565
+  url: https://github.com/eoli3n/dotfiles
 - forks: 5
   name: Felix Volny
   notes: is a one-script install to setup a complete JavaScript development environment


### PR DESCRIPTION
## Summary
- add `eoli3n/dotfiles` to the inspiration list
- include the current star and fork counts from GitHub
- describe its Ansible roles/Jinja-based dotfiles workflow for Sway, fish, Waybar, and Neovim

Closes #258

## Testing
- `python -c "import yaml, pathlib; data=yaml.safe_load(pathlib.Path('_data/inspiration.yml').read_text(encoding='utf-8')); print(len(data))"`
- `git diff --check`

Note: I could not run `script/server` or `bundle exec jekyll build` locally because Ruby/Bundler is not installed in my Windows environment.