### PR TITLE
docs: remove dead bspwm tutorial link

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -35,12 +35,6 @@
   description: >
     Dmitry Geurkov wrote an article about his tool called
     [dotcentral](https://troydm.github.io/blog/2017/02/27/manage-your-dotfiles-like-a-boss/).
-- author: Mark Rabideau
-  description: >
-    Mark Rabideau wrote an article on [Building a bspwm
-    desktop](https://eirenicon.org/knowledge-base/building-a-bspwm-desktop-a-guide/)
-    walking through his setup, including links to the configuration files on
-    github.
 - author: Nicola Paolucci
   description: >
     [Nicola Paolucci](https://www.durdn.com/) wrote a tutorial describing an


### PR DESCRIPTION
Fixes dotfiles/dotfiles.github.com#424.

## Summary
- Remove the `Building a bspwm desktop` tutorial entry because its target URL now returns 404.

## Verification
- `curl -I -L --max-time 20 https://eirenicon.org/knowledge-base/building-a-bspwm-desktop-a-guide/` returns HTTP 404.
- `ruby -e "require 'yaml'; YAML.load_file('_data/tutorials.yml'); puts 'tutorials.yml ok'"`\n- `git diff --check`\n- `rg -n 'Building a bspwm desktop|eirenicon.org/knowledge-base/building-a-bspwm-desktop-a-guide' _data/tutorials.yml || true`\n\nFull Jekyll build was not run locally because this environment is missing the Bundler 2.5.22 version pinned by `Gemfile.lock`.